### PR TITLE
Add aliases to spreadsheet parsing, use quote to escape special characters

### DIFF
--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -10,6 +10,7 @@ import mimetypes
 import requests
 from PIL import Image
 from base64 import b64encode
+from urllib.parse import quote
 import magic  # install me with 'pip install python-magic'
 # https://github.com/ahupp/python-magic
 # this is the site for python-magic in case we need it
@@ -314,7 +315,9 @@ def excel_reader(datafile, sheet, update, connection, patchall):
         if post_json.get("uuid"):
             temp = encodedcc.get_ENCODE(post_json["uuid"], connection)
         elif post_json.get("alias"):
-            temp = encodedcc.get_ENCODE(post_json["alias"], connection)
+            temp = encodedcc.get_ENCODE(quote(post_json["alias"]), connection)
+        elif post_json.get("aliases"):
+            temp = encodedcc.get_ENCODE(quote(post_json["aliases"][0]), connection)
         elif post_json.get("accession"):
             temp = encodedcc.get_ENCODE(post_json["accession"], connection)
         elif post_json.get("@id"):


### PR DESCRIPTION
This fixes 2 problems I encountered when uploading files:

1. Using `aliases:array` columns to patch existing objects (currently the method to read spreadsheets looks for `alias` only (which by the way is not an accepted field, so maybe it can be deleted).
2. Special characters like `-` in the aliases need to be escaped (using the quote function in urllib)

Even if this PR is not merged, maybe you can still fix those issues. I thought this would be an easy way to point to the problems. 