### PR TITLE
5155 patch input typo

### DIFF
--- a/encodedcc.py
+++ b/encodedcc.py
@@ -679,7 +679,7 @@ def patch_set(args, connection):
                         if temp_data[key] in ["True", "true", "TRUE"]:
                             patch_data[k[0]] = True
                         elif temp_data[key] in ["False", "false", "FALSE"]:
-                            patch_input[k[0]] = False
+                            patch_data[k[0]] = False
                 else:
                     patch_data[k[0]] = temp_data[key]
                 old_data = {}

--- a/encodedcc.py
+++ b/encodedcc.py
@@ -658,6 +658,7 @@ def patch_set(args, connection):
             for key in temp_data.keys():
                 k = key.split(":")
                 if len(k) > 1:
+                    k[1] = k[1].lower()
                     if k[1] == "int" or k[1] == "integer":
                         patch_data[k[0]] = int(temp_data[key])
                     elif k[1] == "array" or k[1] == "list":
@@ -675,10 +676,10 @@ def patch_set(args, connection):
                         # this is a dictionary that is being PATCHed
                         temp_data[key] = temp_data[key].replace("'", '"')
                         patch_data[k[0]] = json.loads(temp_data[key])
-                    elif k[1] in ["bool", "Boolean", "boolean", "BOOLEAN"]:
-                        if temp_data[key] in ["True", "true", "TRUE"]:
+                    elif k[1] in ["bool", "boolean"]:
+                        if temp_data[key].lower() == "true":
                             patch_data[k[0]] = True
-                        elif temp_data[key] in ["False", "false", "FALSE"]:
+                        elif temp_data[key].lower() == "false":
                             patch_data[k[0]] = False
                 else:
                     patch_data[k[0]] = temp_data[key]


### PR DESCRIPTION
The first commit fixes a typo in encodedcc.py (undefined patch_input to defined patch_data) and restores functionality for False boolean inputs to ENCODE_patch_set.py. The second commit cleans up the type and value checking by converting the input to lowercase and shortening the comparison list to only values that are also lowercase. http://redmine.encodedcc.org/issues/5155

