### PR TITLE
Wran 633 fix error summary

### DIFF
--- a/ENCODE_error_summary.py
+++ b/ENCODE_error_summary.py
@@ -173,8 +173,8 @@ def main():
         for x in x_buckets:
             full_list.append(x["key"])
     else:
-        full_list = ["RNA-seq", "microRNA profiling by array assay", "microRNA-seq",
-                     "DNase-seq", "whole-genome shotgun bisulfite sequencing", "RAMPAGE", "CAGE"]
+        full_list = ["polyA mRNA RNA-seq", "total RNA-seq", "small RNA-seq", "polyA depleted RNA-seq", "ChIP-seq", "RNA-seq",
+                     "microRNA profiling by array assay", "microRNA-seq", "DNase-seq", "whole-genome shotgun bisulfite sequencing", "RAMPAGE", "CAGE"]
     temp_list = list(full_list)
     if "RNA-seq" in temp_list:
         temp_list.remove("RNA-seq")
@@ -212,9 +212,9 @@ def main():
                     if assay_name in full_list:
                         if assay_list[x] > 0:
                             search = "/search/?type=Experiment&biosample_term_name=" + \
-                                quote(bio_name) + "&assay_term_name=" + \
+                                quote(bio_name) + "&assay_title=" + \
                                 assay_name + full_string
-                            if assay_name == "RNA-seq":
+                            if 'RNA' in assay_name:
                                 short_search = search + "&replicates.library.size_range=<200"
                                 long_search = search + "&replicates.library.size_range!=<200"
 

--- a/ENCODE_error_summary.py
+++ b/ENCODE_error_summary.py
@@ -159,24 +159,27 @@ def main():
             lab_string += "&lab.name=" + r
     full_string = rfa_string + species_string + status_string + lab_string
     search_string += full_string
-    matrix_url = '=HYPERLINK("{}","{}")'.format(connection.server + search_string, connection.server + search_string)
+    matrix_url = '=HYPERLINK("{}","{}")'.format(
+        connection.server + search_string, connection.server + search_string)
 
     matrix = encodedcc.get_ENCODE(search_string, connection).get("matrix")
     x_values = matrix.get("x")
     y_values = matrix.get("y")
 
-    y_buckets = y_values["replicates.library.biosample.biosample_type"].get("buckets")
+    y_buckets = y_values["biosample_type"].get("buckets")
     x_buckets = x_values.get("buckets")
     if args.all:
         full_list = []
         for x in x_buckets:
             full_list.append(x["key"])
     else:
-        full_list = ["RNA-seq", "microRNA profiling by array assay", "microRNA-seq", "DNase-seq", "whole-genome shotgun bisulfite sequencing", "RAMPAGE", "CAGE"]
+        full_list = ["RNA-seq", "microRNA profiling by array assay", "microRNA-seq",
+                     "DNase-seq", "whole-genome shotgun bisulfite sequencing", "RAMPAGE", "CAGE"]
     temp_list = list(full_list)
     if "RNA-seq" in temp_list:
         temp_list.remove("RNA-seq")
-    headers = [matrix_url] + ["Long RNA-seq", "Short RNA-seq"] + temp_list + ["TOTAL"]
+    headers = [matrix_url] + ["Long RNA-seq",
+                              "Short RNA-seq"] + temp_list + ["TOTAL"]
 
     final_assay_search = ""  # this will be used to total rows
     for name in full_list:
@@ -187,7 +190,8 @@ def main():
     for k in col_dict.keys():
         col_dict[k] = []
     with open(args.outfile, "w") as tsvfile:
-        dictwriter = csv.DictWriter(tsvfile, delimiter="\t", fieldnames=headers)
+        dictwriter = csv.DictWriter(
+            tsvfile, delimiter="\t", fieldnames=headers)
         dictwriter.writeheader()
         for y in y_buckets:
             inner_buckets = y["biosample_term_name"].get("buckets")
@@ -197,7 +201,7 @@ def main():
             for item in inner_buckets:
                 bio_name = item["key"]
                 final_bio_search += "&biosample_term_name=" + quote(bio_name)
-                assay_list = item["assay_term_name"]
+                assay_list = item["assay_title"]
                 row_dict = dict.fromkeys(headers)
                 for k in row_dict.keys():
                     row_dict[k] = 0
@@ -207,7 +211,9 @@ def main():
                     assay_name = x_buckets[x]["key"]
                     if assay_name in full_list:
                         if assay_list[x] > 0:
-                            search = "/search/?type=Experiment&biosample_term_name=" + quote(bio_name) + "&assay_term_name=" + assay_name + full_string
+                            search = "/search/?type=Experiment&biosample_term_name=" + \
+                                quote(bio_name) + "&assay_term_name=" + \
+                                assay_name + full_string
                             if assay_name == "RNA-seq":
                                 short_search = search + "&replicates.library.size_range=<200"
                                 long_search = search + "&replicates.library.size_range!=<200"
@@ -215,53 +221,75 @@ def main():
                                 short_url = connection.server + short_search
                                 long_url = connection.server + long_search
 
-                                short_facets = encodedcc.get_ENCODE(short_search, connection)
-                                long_facets = encodedcc.get_ENCODE(long_search, connection)
+                                short_facets = encodedcc.get_ENCODE(
+                                    short_search, connection)
+                                long_facets = encodedcc.get_ENCODE(
+                                    long_search, connection)
 
                                 if short_facets.get("total") == 0:
                                     row_dict["Short RNA-seq"] = 0
                                     row_count.append([0, 0, 0, 0, 0])
-                                    col_dict["Short RNA-seq"].append([0, 0, 0, 0, 0])
+                                    col_dict["Short RNA-seq"].append(
+                                        [0, 0, 0, 0, 0])
                                 else:
-                                    total, error, not_compliant, warning, dcc_action = audit_count(short_facets.get("facets", []), short_facets.get("total"), args.allaudits)
+                                    total, error, not_compliant, warning, dcc_action = audit_count(
+                                        short_facets.get("facets", []), short_facets.get("total"), args.allaudits)
                                     if args.allaudits:
-                                        string = '=HYPERLINK("{}","{}, {}E, {}NC, {}W, {}DCC")'.format(short_url, total, error, not_compliant, warning, dcc_action)
+                                        string = '=HYPERLINK("{}","{}, {}E, {}NC, {}W, {}DCC")'.format(
+                                            short_url, total, error, not_compliant, warning, dcc_action)
                                     else:
-                                        string = '=HYPERLINK("{}","{}, {}E, {}NC")'.format(short_url, total, error, not_compliant)
+                                        string = '=HYPERLINK("{}","{}, {}E, {}NC")'.format(
+                                            short_url, total, error, not_compliant)
                                     row_dict["Short RNA-seq"] = string
-                                    row_count.append([total, error, not_compliant, warning, dcc_action])
-                                    col_dict["Short RNA-seq"].append([total, error, not_compliant, warning, dcc_action])
+                                    row_count.append(
+                                        [total, error, not_compliant, warning, dcc_action])
+                                    col_dict["Short RNA-seq"].append(
+                                        [total, error, not_compliant, warning, dcc_action])
 
                                 if long_facets.get("total") == 0:
                                     row_dict["Long RNA-seq"] = 0
                                     row_count.append([0, 0, 0, 0, 0])
-                                    col_dict["Long RNA-seq"].append([0, 0, 0, 0, 0])
+                                    col_dict["Long RNA-seq"].append(
+                                        [0, 0, 0, 0, 0])
                                 else:
-                                    total, error, not_compliant, warning, dcc_action = audit_count(long_facets.get("facets", []), long_facets.get("total"), args.allaudits)
+                                    total, error, not_compliant, warning, dcc_action = audit_count(
+                                        long_facets.get("facets", []), long_facets.get("total"), args.allaudits)
                                     if args.allaudits:
-                                        string = '=HYPERLINK("{}","{}, {}E, {}NC, {}W, {}DCC")'.format(long_url, total, error, not_compliant, warning, dcc_action)
+                                        string = '=HYPERLINK("{}","{}, {}E, {}NC, {}W, {}DCC")'.format(
+                                            long_url, total, error, not_compliant, warning, dcc_action)
                                     else:
-                                        string = '=HYPERLINK("{}","{}, {}E, {}NC")'.format(long_url, total, error, not_compliant)
+                                        string = '=HYPERLINK("{}","{}, {}E, {}NC")'.format(
+                                            long_url, total, error, not_compliant)
                                     row_dict["Long RNA-seq"] = string
-                                    row_count.append([total, error, not_compliant, warning, dcc_action])
-                                    col_dict["Long RNA-seq"].append([total, error, not_compliant, warning, dcc_action])
+                                    row_count.append(
+                                        [total, error, not_compliant, warning, dcc_action])
+                                    col_dict["Long RNA-seq"].append(
+                                        [total, error, not_compliant, warning, dcc_action])
                             else:
                                 url = connection.server + search
-                                facets = encodedcc.get_ENCODE(search, connection).get("facets", [])
-                                total, error, not_compliant, warning, dcc_action = audit_count(facets, assay_list[x], args.allaudits)
+                                facets = encodedcc.get_ENCODE(
+                                    search, connection).get("facets", [])
+                                total, error, not_compliant, warning, dcc_action = audit_count(
+                                    facets, assay_list[x], args.allaudits)
                                 if args.allaudits:
-                                    string = '=HYPERLINK("{}","{}, {}E, {}NC, {}W, {}DCC")'.format(url, total, error, not_compliant, warning, dcc_action)
+                                    string = '=HYPERLINK("{}","{}, {}E, {}NC, {}W, {}DCC")'.format(
+                                        url, total, error, not_compliant, warning, dcc_action)
                                 else:
-                                    string = '=HYPERLINK("{}","{}, {}E, {}NC")'.format(url, total, error, not_compliant)
-                                row_count.append([total, error, not_compliant, warning, dcc_action])
+                                    string = '=HYPERLINK("{}","{}, {}E, {}NC")'.format(
+                                        url, total, error, not_compliant)
+                                row_count.append(
+                                    [total, error, not_compliant, warning, dcc_action])
                                 row_dict[assay_name] = string
-                                col_dict[assay_name].append([total, error, not_compliant, warning, dcc_action])
+                                col_dict[assay_name].append(
+                                    [total, error, not_compliant, warning, dcc_action])
                         else:
                             if assay_name == "RNA-seq":
                                 row_dict["Short RNA-seq"] = 0
                                 row_dict["Long RNA-seq"] = 0
-                                col_dict["Short RNA-seq"].append([0, 0, 0, 0, 0])
-                                col_dict["Long RNA-seq"].append([0, 0, 0, 0, 0])
+                                col_dict["Short RNA-seq"].append(
+                                    [0, 0, 0, 0, 0])
+                                col_dict["Long RNA-seq"].append(
+                                    [0, 0, 0, 0, 0])
                             else:
                                 row_dict[assay_name] = 0
                                 col_dict[assay_name].append([0, 0, 0, 0, 0])
@@ -272,18 +300,21 @@ def main():
                 row_not_compliant = 0
                 row_warning = 0
                 row_dcc_action = 0
-                bio_total = "/search/?type=Experiment&biosample_term_name=" + quote(bio_name) + final_assay_search + full_string
+                bio_total = "/search/?type=Experiment&biosample_term_name=" + \
+                    quote(bio_name) + final_assay_search + full_string
                 bio_url = connection.server + bio_total
                 for col in row_count:
-                        row_total += col[0]
-                        row_error += col[1]
-                        row_not_compliant += col[2]
-                        row_warning += col[3]
-                        row_dcc_action += col[4]
+                    row_total += col[0]
+                    row_error += col[1]
+                    row_not_compliant += col[2]
+                    row_warning += col[3]
+                    row_dcc_action += col[4]
                 if args.allaudits:
-                    row_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC, {}W, {}DCC")'.format(bio_url, row_total, row_error, row_not_compliant, row_warning, row_dcc_action)
+                    row_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC, {}W, {}DCC")'.format(
+                        bio_url, row_total, row_error, row_not_compliant, row_warning, row_dcc_action)
                 else:
-                    row_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC")'.format(bio_url, row_total, row_error, row_not_compliant)
+                    row_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC")'.format(
+                        bio_url, row_total, row_error, row_not_compliant)
                 dictwriter.writerow(row_dict)
         total = 0
         error = 0
@@ -311,26 +342,34 @@ def main():
                 warning += col_warning
                 dcc_action += col_dcc_action
                 if key == "Long RNA-seq":
-                    assay_total = "/search/?type=Experiment&assay_term_name=RNA-seq&replicates.library.size_range!=<200" + final_bio_search + full_string
+                    assay_total = "/search/?type=Experiment&assay_term_name=RNA-seq&replicates.library.size_range!=<200" + \
+                        final_bio_search + full_string
                 elif key == "Short RNA-seq":
-                    assay_total = "/search/?type=Experiment&assay_term_name=RNA-seq&replicates.library.size_range=<200" + final_bio_search + full_string
+                    assay_total = "/search/?type=Experiment&assay_term_name=RNA-seq&replicates.library.size_range=<200" + \
+                        final_bio_search + full_string
                 else:
-                    assay_total = "/search/?type=Experiment&assay_term_name=" + key + final_bio_search + full_string
+                    assay_total = "/search/?type=Experiment&assay_term_name=" + \
+                        key + final_bio_search + full_string
                 assay_url = connection.server + assay_total
                 if args.allaudits:
-                    total_dict[key] = '=HYPERLINK("{}", "{}, {}E, {}NC, {}W, {}DCC")'.format(assay_url, col_total, col_error, col_not_compliant, col_warning, col_dcc_action)
+                    total_dict[key] = '=HYPERLINK("{}", "{}, {}E, {}NC, {}W, {}DCC")'.format(
+                        assay_url, col_total, col_error, col_not_compliant, col_warning, col_dcc_action)
                 else:
-                    total_dict[key] = '=HYPERLINK("{}", "{}, {}E, {}NC")'.format(assay_url, col_total, col_error, col_not_compliant)
-        full_search = "/search/?type=Experiment" + final_assay_search + final_bio_search + full_string
+                    total_dict[key] = '=HYPERLINK("{}", "{}, {}E, {}NC")'.format(
+                        assay_url, col_total, col_error, col_not_compliant)
+        full_search = "/search/?type=Experiment" + \
+            final_assay_search + final_bio_search + full_string
         full_url = connection.server + full_search
         if args.allaudits:
-            total_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC, {}W, {}DCC")'.format(full_url, total, error, not_compliant, warning, dcc_action)
+            total_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC, {}W, {}DCC")'.format(
+                full_url, total, error, not_compliant, warning, dcc_action)
         else:
-            total_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC")'.format(full_url, total, error, not_compliant)
+            total_dict["TOTAL"] = '=HYPERLINK("{}", "{}, {}E, {}NC")'.format(
+                full_url, total, error, not_compliant)
         dictwriter.writerow(total_dict)
 
     print("Output saved to {}, open this file with Google Docs Sheets, don't use Excel because it sucks".format(args.outfile))
 
 
 if __name__ == '__main__':
-        main()
+    main()


### PR DESCRIPTION
ENCODE_error_summary.py throws a KeyError because of a change in schema on portal. This is a fix to get it running again.

The changes as Aditi explains on https://encodedcc.atlassian.net/browse/WRAN-633: 
> 1) Since this is run on a matrix query, you can't use replicates.library.biosample.biosample_type, because the matrix uses experiment.biosample_type
> 2) All queries now use assay_title instead of assay_term_name, so we had to change that too

The switch from assay_term_name to assay_title also requires specifying all of the specific RNA subtypes (polyA mRNA RNA-seq, total RNA-seq, small RNA-seq, polyA depleted RNA-seq) instead of the generic assay_term_name RNA-seq. The script doesn't report on ChIP-seq assays so this was added to the list as well. 