### PR TITLE
Try to convert string to JSON before Type checking

### DIFF
--- a/encodedcc.py
+++ b/encodedcc.py
@@ -662,8 +662,18 @@ def patch_set(args, connection):
                     if k[1] == "int" or k[1] == "integer":
                         patch_data[k[0]] = int(temp_data[key])
                     elif k[1] == "array" or k[1] == "list":
+                        if type(temp_data[key]) == str:
+                            # So JSON loads if present.
+                            temp_data[key] = temp_data[key].replace("'",'"')
+                        # Try to convert string before testing type. 
+                        try:
+                            temp_data[key] = json.loads(temp_data[key])
+                        except:
+                            pass
                         if type(temp_data[key]) == dict:
                             l = [temp_data[key]]
+                        elif type(temp_data[key]) == list:
+                            l = [t for t in temp_data[key]]
                         else:
                             l = temp_data[key].strip("[]").split(", ")
                             l = [x.replace("'", "") for x in l]


### PR DESCRIPTION
Problem with using ENCODE_patch_set.py to patch lists of objects. Input data always loaded by DictReader as a string and never converted. Code that handles input data of type dict therefore never run. This fix works by trying to convert input string to JSON before type checking occurs.

https://encodedcc.atlassian.net/browse/WRAN-634