### PR TITLE
WRAN-3-import-data-object-fix

### DIFF
--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -252,19 +252,7 @@ def data_formatter(value, val_type):
                          (val_type, value))
 
 
-def expose_objects(new_dict, json_profile):
-    '''
-    Check profile to see if value should be object instead of 
-    list of objects.
-    '''
-    for key in new_dict.keys():
-        if ((len(new_dict[key]) == 1)
-                and (json_profile[key]['type'] == 'object')):
-            new_dict[key] = new_dict[key][0]
-    return new_dict
-
-
-def dict_patcher(old_dict, json_profile):
+def dict_patcher(old_dict):
     new_dict = {}
     for key in old_dict.keys():
         if old_dict[key] != "":  # this removes empty cells
@@ -327,8 +315,19 @@ def dict_patcher(old_dict, json_profile):
                     # make new item in dictionary
                     temp_dict = {path[1]: data_formatter(old_dict[key], k[1])}
                     new_dict[path[0]] = [temp_dict]
-    new_dict = expose_objects(new_dict, json_profile)
     return new_dict
+
+
+def expose_objects(post_json, json_properties):
+    '''
+    Check profile to see if value should be object instead of 
+    list of objects.
+    '''
+    for key in post_json.keys():
+        if ((len(post_json[key]) == 1)
+                and (json_properties[key]['type'] == 'object')):
+            post_json[key] = post_json[key][0]
+    return post_json
 
 
 def excel_reader(datafile, sheet, update, connection, patchall):
@@ -338,12 +337,13 @@ def excel_reader(datafile, sheet, update, connection, patchall):
     error = 0
     success = 0
     patch = 0
-    json_profile = encodedcc.get_ENCODE(
+    json_properties = encodedcc.get_ENCODE(
         '/profiles/{}.json'.format(sheet), connection)['properties']
     for values in row:
         total += 1
         post_json = dict(zip(keys, values))
-        post_json = dict_patcher(post_json, json_profile)
+        post_json = dict_patcher(post_json)
+        post_json = expose_objects(post_json, json_properties)
         # add attchments here
         if post_json.get("attachment"):
             attach = attachment(post_json["attachment"])

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -245,7 +245,7 @@ def data_formatter(value, val_type):
         else:
             raise ValueError('Boolean was expected but got: %s, %s' %
                              (value, type(value)))
-    elif val_type in ["obj", "object"]:
+    elif val_type in ["json", "object"]:
         return json.loads(value)
     else:
         raise ValueError('Unrecognized type: %s for value: %s' %

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -8,7 +8,7 @@ import datetime
 import sys
 import mimetypes
 import requests
-from PIL import Image # install me with 'pip3 install Pillow'
+from PIL import Image  # install me with 'pip3 install Pillow'
 from urllib.parse import quote
 from base64 import b64encode
 import magic  # install me with 'pip3 install python-magic'
@@ -152,7 +152,8 @@ def attachment(path):
     # XXX This validation logic should move server-side.
     if not (detected_type == mime_type or
             detected_type == 'text/plain' and major == 'text'):
-        raise ValueError('Wrong extension for %s: %s' % (detected_type, filename))
+        raise ValueError('Wrong extension for %s: %s' %
+                         (detected_type, filename))
 
     with open(path, 'rb') as stream:
         attach = {
@@ -241,10 +242,11 @@ def data_formatter(value, val_type):
         elif value in ["False", "FALSE", 0, "0"]:
             return False
         else:
-            raise ValueError('Boolean was expected but got: %s, %s' % (value, type(value)))
+            raise ValueError('Boolean was expected but got: %s, %s' %
+                             (value, type(value)))
     else:
-        raise ValueError('Unrecognized type: %s for value: %s' % (val_type, value))
-        
+        raise ValueError('Unrecognized type: %s for value: %s' %
+                         (val_type, value))
 
 
 def dict_patcher(old_dict):
@@ -272,10 +274,12 @@ def dict_patcher(old_dict):
                         # this has a number next to it
                         if len(new_dict[path[0]]) == int(value[1]):
                             # this means we have not added any part of new item to the list
-                            new_dict[path[0]].insert(int(value[1]), {value[0]: old_dict[key]})
+                            new_dict[path[0]].insert(
+                                int(value[1]), {value[0]: old_dict[key]})
                         else:
                             # this should be that we have started putting in the new object
-                            new_dict[path[0]][int(value[1])].update({value[0]: old_dict[key]})
+                            new_dict[path[0]][int(value[1])].update(
+                                {value[0]: old_dict[key]})
                     else:
                         # the object does not exist in the embedded part, add it
                         new_dict[path[0]][0].update({path[1]: old_dict[key]})
@@ -294,13 +298,16 @@ def dict_patcher(old_dict):
                         # this has a number next to it
                         if len(new_dict[path[0]]) == int(value[1]):
                             # this means we have not added any part of new item to the list
-                            new_dict[path[0]].insert(int(value[1]), {value[0]: old_dict[key]})
+                            new_dict[path[0]].insert(
+                                int(value[1]), {value[0]: old_dict[key]})
                         else:
                             # this should be that we have started putting in the new object
-                            new_dict[path[0]][int(value[1])].update({value[0]: old_dict[key]})
+                            new_dict[path[0]][int(value[1])].update(
+                                {value[0]: old_dict[key]})
                     else:
                         # the object does not exist in the embedded part, add it
-                        new_dict[path[0]][0].update({path[1]: data_formatter(old_dict[key], k[1])})
+                        new_dict[path[0]][0].update(
+                            {path[1]: data_formatter(old_dict[key], k[1])})
                 else:
                     # make new item in dictionary
                     temp_dict = {path[1]: data_formatter(old_dict[key], k[1])}
@@ -343,10 +350,12 @@ def excel_reader(datafile, sheet, update, connection, patchall):
                     success += 1
                     patch += 1
             else:
-                print("Object {} already exists.  Would you like to patch it instead?".format(temp["uuid"]))
+                print("Object {} already exists.  Would you like to patch it instead?".format(
+                    temp["uuid"]))
                 i = input("PATCH? y/n ")
                 if i.lower() == "y":
-                    e = encodedcc.patch_ENCODE(temp["uuid"], connection, post_json)
+                    e = encodedcc.patch_ENCODE(
+                        temp["uuid"], connection, post_json)
                     if e["status"] == "error":
                         error += 1
                     elif e["status"] == "success":
@@ -382,9 +391,12 @@ def main():
     supported_collections = [s.lower() for s in list(profiles.keys())]
     for n in names:
         if n.lower() in supported_collections:
-            excel_reader(args.infile, n, args.update, connection, args.patchall)
+            excel_reader(args.infile, n, args.update,
+                         connection, args.patchall)
         else:
-            print("Sheet name '{name}' not part of supported object types!".format(name=n), file=sys.stderr)
+            print("Sheet name '{name}' not part of supported object types!".format(
+                name=n), file=sys.stderr)
+
 
 if __name__ == '__main__':
-        main()
+    main()

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -3,6 +3,7 @@
 import argparse
 import os.path
 import encodedcc
+import json
 import xlrd
 import datetime
 import sys
@@ -244,6 +245,8 @@ def data_formatter(value, val_type):
         else:
             raise ValueError('Boolean was expected but got: %s, %s' %
                              (value, type(value)))
+    elif val_type in ["obj", "object"]:
+        return json.loads(value)
     else:
         raise ValueError('Unrecognized type: %s for value: %s' %
                          (val_type, value))

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -335,15 +335,17 @@ def excel_reader(datafile, sheet, update, connection, patchall):
             post_json["attachment"] = attach
         print(post_json)
         temp = {}
-        if post_json.get("uuid"):
-            temp = encodedcc.get_ENCODE(post_json["uuid"], connection)
-        elif post_json.get("aliases"):
-            temp = encodedcc.get_ENCODE(quote(post_json["aliases"][0]),
-                                        connection)
-        elif post_json.get("accession"):
-            temp = encodedcc.get_ENCODE(post_json["accession"], connection)
-        elif post_json.get("@id"):
-            temp = encodedcc.get_ENCODE(post_json["@id"], connection)
+        # Silence get_ENCODE failures.
+        with encodedcc.print_muted():
+            if post_json.get("uuid"):
+                temp = encodedcc.get_ENCODE(post_json["uuid"], connection)
+            elif post_json.get("aliases"):
+                temp = encodedcc.get_ENCODE(quote(post_json["aliases"][0]),
+                                            connection)
+            elif post_json.get("accession"):
+                temp = encodedcc.get_ENCODE(post_json["accession"], connection)
+            elif post_json.get("@id"):
+                temp = encodedcc.get_ENCODE(post_json["@id"], connection)
         if temp.get("uuid"):
             if patchall:
                 e = encodedcc.patch_ENCODE(temp["uuid"], connection, post_json)

--- a/encodedcc.py
+++ b/encodedcc.py
@@ -12,11 +12,13 @@ import hashlib
 import copy
 import subprocess
 
+
 class dict_diff(object):
     """
     Calculate items added, items removed, keys same in both but changed values,
     keys same in both and unchanged values
     """
+
     def __init__(self, current_dict, past_dict):
         self.current_dict, self.past_dict = current_dict, past_dict
         self.current_keys, self.past_keys = [
@@ -77,7 +79,8 @@ class ENC_Key:
 
 class ENC_Connection(object):
     def __init__(self, key):
-        self.headers = {'content-type': 'application/json', 'accept': 'application/json'}
+        self.headers = {'content-type': 'application/json',
+                        'accept': 'application/json'}
         self.server = key.server
         self.auth = (key.authid, key.authpw)
 
@@ -116,6 +119,7 @@ class ENC_Collection(object):
                                             doc_type=self.search_name,
                                             size=maxhits)
         return results
+
 
 global schemas
 schemas = []
@@ -202,7 +206,8 @@ class ENC_Item(object):
                     else:
                         pass
                 # should return the new object that comes back from the patch
-                new_object = replace_ENCODE(self.id, self.connection, put_payload)
+                new_object = replace_ENCODE(
+                    self.id, self.connection, put_payload)
 
             else:  # PATCH
 
@@ -212,7 +217,8 @@ class ENC_Item(object):
                     if prop not in excluded_from_patch:
                         patch_payload.update({prop: self.properties[prop]})
                 # should probably return the new object that comes back from the patch
-                new_object = patch_ENCODE(self.id, self.connection, patch_payload)
+                new_object = patch_ENCODE(
+                    self.id, self.connection, patch_payload)
 
         return new_object
 
@@ -231,26 +237,29 @@ def get_ENCODE(obj_id, connection, frame="object"):
     '''GET an ENCODE object as JSON and return as dict'''
     if frame is None:
         if '?' in obj_id:
-            url = urljoin(connection.server, obj_id+'&limit=all')
+            url = urljoin(connection.server, obj_id + '&limit=all')
         else:
-            url = urljoin(connection.server, obj_id+'?limit=all')
+            url = urljoin(connection.server, obj_id + '?limit=all')
     elif '?' in obj_id:
-        url = urljoin(connection.server, obj_id+'&limit=all&frame='+frame)
+        url = urljoin(connection.server, obj_id + '&limit=all&frame=' + frame)
     else:
-        url = urljoin(connection.server, obj_id+'?limit=all&frame='+frame)
+        url = urljoin(connection.server, obj_id + '?limit=all&frame=' + frame)
     logging.debug('GET %s' % (url))
-    response = requests.get(url, auth=connection.auth, headers=connection.headers)
+    response = requests.get(url, auth=connection.auth,
+                            headers=connection.headers)
     logging.debug('GET RESPONSE code %s' % (response.status_code))
     try:
         if response.json():
-            logging.debug('GET RESPONSE JSON: %s' % (json.dumps(response.json(), indent=4, separators=(',', ': '))))
+            logging.debug('GET RESPONSE JSON: %s' % (json.dumps(
+                response.json(), indent=4, separators=(',', ': '))))
     except:
         logging.debug('GET RESPONSE text %s' % (response.text))
     if not response.status_code == 200:
         if response.json().get("notification"):
             logging.warning('%s' % (response.json().get("notification")))
         else:
-            logging.warning('GET failure.  Response code = %s' % (response.text))
+            logging.warning('GET failure.  Response code = %s' %
+                            (response.text))
     return response.json()
 
 
@@ -308,17 +317,17 @@ def new_ENCODE(connection, collection_name, post_input):
     url = urljoin(connection.server, collection_name)
     logging.debug("POST URL : %s" % (url))
     logging.debug("POST data: %s" % (json.dumps(post_input,
-                                     sort_keys=True, indent=4,
-                                     separators=(',', ': '))))
+                                                sort_keys=True, indent=4,
+                                                separators=(',', ': '))))
     response = requests.post(url, auth=connection.auth,
                              headers=connection.headers, data=json_payload)
     logging.debug("POST RESPONSE: %s" % (json.dumps(response.json(),
-                                         indent=4, separators=(',', ': '))))
+                                                    indent=4, separators=(',', ': '))))
     if not response.status_code == 201:
         logging.warning('POST failure. Response = %s' % (response.text))
     logging.debug("Return object: %s" % (json.dumps(response.json(),
-                                         sort_keys=True, indent=4,
-                                         separators=(',', ': '))))
+                                                    sort_keys=True, indent=4,
+                                                    separators=(',', ': '))))
     return response.json()
 
 
@@ -377,17 +386,21 @@ class GetFields():
             temp = []
             if self.args.collection:
                 if self.args.es:
-                    temp = get_ENCODE("/search/?type=" + self.args.collection, self.connection).get("@graph", [])
+                    temp = get_ENCODE(
+                        "/search/?type=" + self.args.collection, self.connection).get("@graph", [])
                 else:
-                    temp = get_ENCODE(self.args.collection, self.connection, frame=None).get("@graph", [])
+                    temp = get_ENCODE(
+                        self.args.collection, self.connection, frame=None).get("@graph", [])
             elif self.args.query:
                 if "search" in self.args.query:
-                    temp = get_ENCODE(self.args.query, self.connection).get("@graph", [])
+                    temp = get_ENCODE(
+                        self.args.query, self.connection).get("@graph", [])
                 else:
                     temp = [get_ENCODE(self.args.query, self.connection)]
             elif self.args.infile:
                 if os.path.isfile(self.args.infile):
-                    self.accessions = [line.strip() for line in open(self.args.infile)]
+                    self.accessions = [line.strip()
+                                       for line in open(self.args.infile)]
                 else:
                     self.accessions = self.args.infile.split(",")
             if any(temp):
@@ -404,11 +417,14 @@ class GetFields():
                         print("ERROR: object has no identifier", file=sys.stderr)
             if self.args.allfields:
                 if self.args.collection:
-                    obj = get_ENCODE("/profiles/" + self.args.collection + ".json", self.connection).get("properties")
+                    obj = get_ENCODE(
+                        "/profiles/" + self.args.collection + ".json", self.connection).get("properties")
                 else:
-                    obj_type = get_ENCODE(self.accessions[0], self.connection).get("@type")
+                    obj_type = get_ENCODE(
+                        self.accessions[0], self.connection).get("@type")
                     if any(obj_type):
-                        obj = get_ENCODE("/profiles/" + obj_type[0] + ".json", self.connection).get("properties")
+                        obj = get_ENCODE(
+                            "/profiles/" + obj_type[0] + ".json", self.connection).get("properties")
                 self.fields = list(obj.keys())
                 for key in obj.keys():
                     if obj[key]["type"] == "string":
@@ -418,7 +434,8 @@ class GetFields():
                 self.header.sort()
             elif self.args.field:
                 if os.path.isfile(self.args.field):
-                    self.fields = [line.strip() for line in open(self.args.field)]
+                    self.fields = [line.strip()
+                                   for line in open(self.args.field)]
                 else:
                     self.fields = self.args.field.split(",")
         if len(self.accessions) == 0:
@@ -439,8 +456,10 @@ class GetFields():
             newObj = {}
             newObj["accession"] = acc
             for f in self.fields:
-                path = deque(f.split("."))  # check to see if someone wants embedded value
-                field = self.get_embedded(path, obj)  # get the last element in the split list
+                # check to see if someone wants embedded value
+                path = deque(f.split("."))
+                # get the last element in the split list
+                field = self.get_embedded(path, obj)
                 if field:  # after the above loop, should have final field value
                     name = f
                     if not self.facet:
@@ -451,7 +470,8 @@ class GetFields():
                             self.header.append(name)
             self.data.append(newObj)
         if not self.facet:
-            writer = csv.DictWriter(sys.stdout, delimiter='\t', fieldnames=self.header)
+            writer = csv.DictWriter(
+                sys.stdout, delimiter='\t', fieldnames=self.header)
             writer.writeheader()
             for d in self.data:
                 writer.writerow(d)
@@ -523,21 +543,25 @@ class GetFields():
                         temp = get_ENCODE(f, self.connection)
                         if temp.get(path[0]):
                             if len(path) == 1:  # if last element in path then get from each item in list
-                                files_list.append(temp[path[0]])  # add items to list
+                                # add items to list
+                                files_list.append(temp[path[0]])
                             else:
                                 return self.get_embedded(path, temp)
                     if self.args.listfull:
                         return files_list
                     else:
-                        return list(set(files_list))  # return unique list of last element items
+                        # return unique list of last element items
+                        return list(set(files_list))
                 else:
                     if type(obj[field]) == int:
-                        return obj[field]  # just return integers as is, we can't expand them
+                        # just return integers as is, we can't expand them
+                        return obj[field]
                     elif type(obj[field]) == list:
                         if len(path) == 1:  # if last element in path then get from each item in list
                             files_list = []
                             for f in obj[field]:
-                                if type(f) == dict:  # if this is like a flowcell or something it should catch here
+                                # if this is like a flowcell or something it should catch here
+                                if type(f) == dict:
                                     return f
                                 temp = get_ENCODE(f, self.connection)
                                 if temp.get(path[0]):
@@ -548,16 +572,20 @@ class GetFields():
                             if self.args.listfull:
                                 return files_list
                             else:
-                                return list(set(files_list))  # return unique list of last element items
+                                # return unique list of last element items
+                                return list(set(files_list))
                         elif self.facet:  # facet is a special case for the search page flattener
                             temp = get_ENCODE(obj[field][0], self.connection)
                             return self.get_embedded(path, temp)
                         else:  # if this is not the last item in the path, but we are in a list
-                            return obj[field]  # return the item since we can't dig deeper without getting lost
+                            # return the item since we can't dig deeper without getting lost
+                            return obj[field]
                     elif type(obj[field]) == dict:
-                        return obj[field]  # return dictionary objects, probably things like flowcells anyways
+                        # return dictionary objects, probably things like flowcells anyways
+                        return obj[field]
                     else:
-                        temp = get_ENCODE(obj[field], self.connection)  # if found get_ENCODE the embedded object
+                        # if found get_ENCODE the embedded object
+                        temp = get_ENCODE(obj[field], self.connection)
                         return self.get_embedded(path, temp)
             else:  # if not obj.get(field) then we kick back an error
                 return ""
@@ -664,8 +692,8 @@ def patch_set(args, connection):
                     elif k[1] == "array" or k[1] == "list":
                         if type(temp_data[key]) == str:
                             # So JSON loads if present.
-                            temp_data[key] = temp_data[key].replace("'",'"')
-                        # Try to convert string before testing type. 
+                            temp_data[key] = temp_data[key].replace("'", '"')
+                        # Try to convert string before testing type.
                         try:
                             temp_data[key] = json.loads(temp_data[key])
                         except:
@@ -680,7 +708,8 @@ def patch_set(args, connection):
                         if args.overwrite:
                             patch_data[k[0]] = l
                         else:
-                            append_list = get_ENCODE(accession, connection).get(k[0], [])
+                            append_list = get_ENCODE(
+                                accession, connection).get(k[0], [])
                             patch_data[k[0]] = l + append_list
                     elif k[1] == "dict":
                         # this is a dictionary that is being PATCHed
@@ -735,7 +764,7 @@ def fastq_read(connection, uri=None, filename=None, reads=1):
 def md5(path):
     md5sum = hashlib.md5()
     with open(path, 'rb') as f:
-        for chunk in iter(lambda: f.read(1024*1024), b''):
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
             md5sum.update(chunk)
     return md5sum.hexdigest()
 
@@ -750,7 +779,8 @@ def post_file(file_metadata, connection, update=False):
         pass
     if update:
         url = urljoin(connection.server, '/files/')
-        r = requests.post(url, auth=connection.auth, headers=connection.headers, data=json.dumps(file_metadata))
+        r = requests.post(url, auth=connection.auth,
+                          headers=connection.headers, data=json.dumps(file_metadata))
         try:
             r.raise_for_status()
         except:
@@ -758,7 +788,8 @@ def post_file(file_metadata, connection, update=False):
             if r.status_code == 409:
                 return r
             else:
-                logging.warning('POST failed: %s %s' % (r.status_code, r.reason))
+                logging.warning('POST failed: %s %s' %
+                                (r.status_code, r.reason))
                 logging.warning(r.text)
                 return None
         else:
@@ -784,10 +815,12 @@ def upload_file(file_obj, update=False):
         })
         path = file_obj.get('submitted_file_name')
         try:
-            subprocess.check_call(['aws', 's3', 'cp', path, creds['upload_url']], env=env)
+            subprocess.check_call(
+                ['aws', 's3', 'cp', path, creds['upload_url']], env=env)
         except subprocess.CalledProcessError as e:
             # The aws command returns a non-zero exit code on error.
-            logging.error("AWS upload failed with exit code %d" % (e.returncode))
+            logging.error("AWS upload failed with exit code %d" %
+                          (e.returncode))
             return e.returncode
         else:
             return 0

--- a/encodedcc.py
+++ b/encodedcc.py
@@ -12,6 +12,23 @@ import hashlib
 import copy
 import subprocess
 
+from contextlib import contextmanager
+
+
+@contextmanager
+def print_muted():
+    '''
+    Temporarily redirects stdout and stderr and disables logging to silence
+    any printing within the with print_muted(): context.
+    '''
+    with open(os.devnull, 'w') as null:
+        _stdout, _stderr = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = null, null
+        logging.getLogger().disabled = True
+        yield
+        sys.stdout, sys.stderr = _stdout, _stderr
+        logging.getLogger().disabled = False
+
 
 class dict_diff(object):
     """


### PR DESCRIPTION
Allows ENCODE_import_data.py to post objects instead of a list of objects (necessary for fields such as genetic_modifications.modified_site_by_coordinates which require an object and not a list containing an object).

* Builds object from Excel infile as before but checks profile JSON to see if field is object instead of list, pulling object out of list if it is. 
* Allows use of :object or :json in Excel column in case anyone would rather put the entire JSON object in one cell.
* Outputs the accession/UUID of created object when it posts and makes clear which objects had posting success or failure.