### PR TITLE
WRAN-683-import-data-object-fix

### DIFF
--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -252,19 +252,7 @@ def data_formatter(value, val_type):
                          (val_type, value))
 
 
-def expose_objects(new_dict, json_profile):
-    '''
-    Check profile to see if value should be object instead of 
-    list of objects.
-    '''
-    for key in new_dict.keys():
-        if ((len(new_dict[key]) == 1)
-                and (json_profile[key]['type'] == 'object')):
-            new_dict[key] = new_dict[key][0]
-    return new_dict
-
-
-def dict_patcher(old_dict, json_profile):
+def dict_patcher(old_dict):
     new_dict = {}
     for key in old_dict.keys():
         if old_dict[key] != "":  # this removes empty cells
@@ -327,8 +315,19 @@ def dict_patcher(old_dict, json_profile):
                     # make new item in dictionary
                     temp_dict = {path[1]: data_formatter(old_dict[key], k[1])}
                     new_dict[path[0]] = [temp_dict]
-    new_dict = expose_objects(new_dict, json_profile)
     return new_dict
+
+
+def expose_objects(post_json, json_properties):
+    '''
+    Check profile to see if value should be object instead of 
+    list of objects.
+    '''
+    for key in post_json.keys():
+        if ((len(post_json[key]) == 1)
+                and (json_properties[key]['type'] == 'object')):
+            post_json[key] = post_json[key][0]
+    return post_json
 
 
 def excel_reader(datafile, sheet, update, connection, patchall):
@@ -338,12 +337,13 @@ def excel_reader(datafile, sheet, update, connection, patchall):
     error = 0
     success = 0
     patch = 0
-    json_profile = encodedcc.get_ENCODE(
+    json_properties = encodedcc.get_ENCODE(
         '/profiles/{}.json'.format(sheet), connection)['properties']
     for values in row:
         total += 1
         post_json = dict(zip(keys, values))
-        post_json = dict_patcher(post_json, json_profile)
+        post_json = dict_patcher(post_json)
+        post_json = expose_objects(post_json, json_properties)
         # add attchments here
         if post_json.get("attachment"):
             attach = attachment(post_json["attachment"])

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -254,7 +254,7 @@ def data_formatter(value, val_type):
 
 def dict_patcher(old_dict):
     new_dict = {}
-    for key in old_dict.keys():
+    for key in sorted(old_dict.keys()):
         if old_dict[key] != "":  # this removes empty cells
             k = key.split(":")
             path = k[0].split(".")

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -245,7 +245,7 @@ def data_formatter(value, val_type):
         else:
             raise ValueError('Boolean was expected but got: %s, %s' %
                              (value, type(value)))
-    elif val_type in ["obj", "object"]:
+    elif val_type in ["json", "object"]:
         return json.loads(value)
     else:
         raise ValueError('Unrecognized type: %s for value: %s' %

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -8,7 +8,7 @@ import datetime
 import sys
 import mimetypes
 import requests
-from PIL import Image # install me with 'pip3 install Pillow'
+from PIL import Image  # install me with 'pip3 install Pillow'
 from urllib.parse import quote
 from base64 import b64encode
 import magic  # install me with 'pip3 install python-magic'
@@ -152,7 +152,8 @@ def attachment(path):
     # XXX This validation logic should move server-side.
     if not (detected_type == mime_type or
             detected_type == 'text/plain' and major == 'text'):
-        raise ValueError('Wrong extension for %s: %s' % (detected_type, filename))
+        raise ValueError('Wrong extension for %s: %s' %
+                         (detected_type, filename))
 
     with open(path, 'rb') as stream:
         attach = {
@@ -241,10 +242,11 @@ def data_formatter(value, val_type):
         elif value in ["False", "FALSE", 0, "0"]:
             return False
         else:
-            raise ValueError('Boolean was expected but got: %s, %s' % (value, type(value)))
+            raise ValueError('Boolean was expected but got: %s, %s' %
+                             (value, type(value)))
     else:
-        raise ValueError('Unrecognized type: %s for value: %s' % (val_type, value))
-        
+        raise ValueError('Unrecognized type: %s for value: %s' %
+                         (val_type, value))
 
 
 def dict_patcher(old_dict):
@@ -272,10 +274,12 @@ def dict_patcher(old_dict):
                         # this has a number next to it
                         if len(new_dict[path[0]]) == int(value[1]):
                             # this means we have not added any part of new item to the list
-                            new_dict[path[0]].insert(int(value[1]), {value[0]: old_dict[key]})
+                            new_dict[path[0]].insert(
+                                int(value[1]), {value[0]: old_dict[key]})
                         else:
                             # this should be that we have started putting in the new object
-                            new_dict[path[0]][int(value[1])].update({value[0]: old_dict[key]})
+                            new_dict[path[0]][int(value[1])].update(
+                                {value[0]: old_dict[key]})
                     else:
                         # the object does not exist in the embedded part, add it
                         new_dict[path[0]][0].update({path[1]: old_dict[key]})
@@ -294,13 +298,16 @@ def dict_patcher(old_dict):
                         # this has a number next to it
                         if len(new_dict[path[0]]) == int(value[1]):
                             # this means we have not added any part of new item to the list
-                            new_dict[path[0]].insert(int(value[1]), {value[0]: old_dict[key]})
+                            new_dict[path[0]].insert(
+                                int(value[1]), {value[0]: old_dict[key]})
                         else:
                             # this should be that we have started putting in the new object
-                            new_dict[path[0]][int(value[1])].update({value[0]: old_dict[key]})
+                            new_dict[path[0]][int(value[1])].update(
+                                {value[0]: old_dict[key]})
                     else:
                         # the object does not exist in the embedded part, add it
-                        new_dict[path[0]][0].update({path[1]: data_formatter(old_dict[key], k[1])})
+                        new_dict[path[0]][0].update(
+                            {path[1]: data_formatter(old_dict[key], k[1])})
                 else:
                     # make new item in dictionary
                     temp_dict = {path[1]: data_formatter(old_dict[key], k[1])}
@@ -343,10 +350,12 @@ def excel_reader(datafile, sheet, update, connection, patchall):
                     success += 1
                     patch += 1
             else:
-                print("Object {} already exists.  Would you like to patch it instead?".format(temp["uuid"]))
+                print("Object {} already exists.  Would you like to patch it instead?".format(
+                    temp["uuid"]))
                 i = input("PATCH? y/n ")
                 if i.lower() == "y":
-                    e = encodedcc.patch_ENCODE(temp["uuid"], connection, post_json)
+                    e = encodedcc.patch_ENCODE(
+                        temp["uuid"], connection, post_json)
                     if e["status"] == "error":
                         error += 1
                     elif e["status"] == "success":
@@ -382,9 +391,12 @@ def main():
     supported_collections = [s.lower() for s in list(profiles.keys())]
     for n in names:
         if n.lower() in supported_collections:
-            excel_reader(args.infile, n, args.update, connection, args.patchall)
+            excel_reader(args.infile, n, args.update,
+                         connection, args.patchall)
         else:
-            print("Sheet name '{name}' not part of supported object types!".format(name=n), file=sys.stderr)
+            print("Sheet name '{name}' not part of supported object types!".format(
+                name=n), file=sys.stderr)
+
 
 if __name__ == '__main__':
-        main()
+    main()

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -3,6 +3,7 @@
 import argparse
 import os.path
 import encodedcc
+import json
 import xlrd
 import datetime
 import sys
@@ -244,6 +245,8 @@ def data_formatter(value, val_type):
         else:
             raise ValueError('Boolean was expected but got: %s, %s' %
                              (value, type(value)))
+    elif val_type in ["obj", "object"]:
+        return json.loads(value)
     else:
         raise ValueError('Unrecognized type: %s for value: %s' %
                          (val_type, value))

--- a/ENCODE_import_data.py
+++ b/ENCODE_import_data.py
@@ -335,15 +335,17 @@ def excel_reader(datafile, sheet, update, connection, patchall):
             post_json["attachment"] = attach
         print(post_json)
         temp = {}
-        if post_json.get("uuid"):
-            temp = encodedcc.get_ENCODE(post_json["uuid"], connection)
-        elif post_json.get("aliases"):
-            temp = encodedcc.get_ENCODE(quote(post_json["aliases"][0]),
-                                        connection)
-        elif post_json.get("accession"):
-            temp = encodedcc.get_ENCODE(post_json["accession"], connection)
-        elif post_json.get("@id"):
-            temp = encodedcc.get_ENCODE(post_json["@id"], connection)
+        # Silence get_ENCODE failures.
+        with encodedcc.print_muted():
+            if post_json.get("uuid"):
+                temp = encodedcc.get_ENCODE(post_json["uuid"], connection)
+            elif post_json.get("aliases"):
+                temp = encodedcc.get_ENCODE(quote(post_json["aliases"][0]),
+                                            connection)
+            elif post_json.get("accession"):
+                temp = encodedcc.get_ENCODE(post_json["accession"], connection)
+            elif post_json.get("@id"):
+                temp = encodedcc.get_ENCODE(post_json["@id"], connection)
         if temp.get("uuid"):
             if patchall:
                 e = encodedcc.patch_ENCODE(temp["uuid"], connection, post_json)

--- a/encodedcc.py
+++ b/encodedcc.py
@@ -12,6 +12,23 @@ import hashlib
 import copy
 import subprocess
 
+from contextlib import contextmanager
+
+
+@contextmanager
+def print_muted():
+    '''
+    Temporarily redirects stdout and stderr and disables logging to silence
+    any printing within the with print_muted(): context.
+    '''
+    with open(os.devnull, 'w') as null:
+        _stdout, _stderr = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = null, null
+        logging.getLogger().disabled = True
+        yield
+        sys.stdout, sys.stderr = _stdout, _stderr
+        logging.getLogger().disabled = False
+
 
 class dict_diff(object):
     """


### PR DESCRIPTION
Allows ENCODE_import_data.py to post objects instead of a list of objects (necessary for fields such as genetic_modifications.modified_site_by_coordinates which require an object and not a list containing an object).

* Builds object from Excel infile as before but checks profile JSON to see if field is object instead of list, pulling object out of list if it is. 
* Allows use of :object or :json in Excel column in case anyone would rather put the entire JSON object in one cell.
* Outputs the accession/UUID of created object when it posts and makes clear which objects had posting success or failure.
* Silences expected GET failures when checking if object already exists before posting.