### PR TITLE
ENCD-3589-stitching-error

### DIFF
--- a/qancode/comparisons.py
+++ b/qancode/comparisons.py
@@ -260,6 +260,11 @@ class CompareScreenShots(URLComparison):
         print('Item type: {}'.format(self.item_type))
         print('Click path: {}'.format(
             None if self.click_path is None else self.click_path.__name__))
-        result = self.compute_image_difference()
-        print('Distance metric: {}'.format(self.diff_distance_metric))
-        return result
+        try:
+            result = self.compute_image_difference()
+            print('Distance metric: {}'.format(self.diff_distance_metric))
+            return result
+        except IndexError:
+            print('{}COMPARISON ERROR. SKIPPING.{}'.format(bcolors.FAIL, bcolors.ENDC))
+            return ('FAIL', self.item_type)
+    

--- a/qancode/tasks.py
+++ b/qancode/tasks.py
@@ -475,7 +475,7 @@ class GetScreenShot(SeleniumTask):
         scroll_height = self.driver.execute_script(
             'return document.body.scrollHeight;')
         if ((self.driver.capabilities['browserName'] == 'safari')
-                or (client_height == scroll_height)):
+                or (np.allclose(client_height, scroll_height, rtol=0.0025))):
             self.driver.save_screenshot(image_path)
         else:
             self.stitch_image(image_path)

--- a/qancode/tasks.py
+++ b/qancode/tasks.py
@@ -418,6 +418,8 @@ class GetScreenShot(SeleniumTask):
     """
     Get screenshot for comparison.
     """
+    # Image shape comparison tolerance.
+    RTOL = 0.0025
 
     def stitch_image(self, image_path):
         print('Stitching screenshot')
@@ -436,10 +438,10 @@ class GetScreenShot(SeleniumTask):
             image = Image.open(
                 BytesIO(self.driver.get_screenshot_as_png())).convert('RGB')
             if ((((2 * client_height) + scroll_top) >= scroll_height)
-                    and (not np.allclose(scroll_height, (client_height + scroll_top), rtol=0.0025))):
+                    and not (np.allclose(scroll_height, (client_height + scroll_top), rtol=self.RTOL))):
                 difference_to_keep = abs(
                     (scroll_height - (client_height + scroll_top)))
-            if np.allclose(scroll_height, (client_height + scroll_top), rtol=0.0025):
+            if np.allclose(scroll_height, (client_height + scroll_top), rtol=self.RTOL):
                 image = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
                 # Compensate for retina displays with twice as many pixels.
                 # Usual client_height is <900 given .set_window_size(1500, 950).
@@ -475,7 +477,7 @@ class GetScreenShot(SeleniumTask):
         scroll_height = self.driver.execute_script(
             'return document.body.scrollHeight;')
         if ((self.driver.capabilities['browserName'] == 'safari')
-                or (np.allclose(client_height, scroll_height, rtol=0.0025))):
+                or (np.allclose(client_height, scroll_height, rtol=self.RTOL))):
             self.driver.save_screenshot(image_path)
         else:
             self.stitch_image(image_path)


### PR DESCRIPTION
This fixes a subtle bug in the way a page is determined to need screenshot stitching or not.

Two changes:
1. If the entire page and the visible page are very similar (rather than exactly the same) in size don’t try to stitch.
2. If image comparison fails continue on to next (not good to have whole thing crash after collecting hundreds of images).

Detailed description of the issue in the ticket. https://encodedcc.atlassian.net/browse/ENCD-3589