### PR TITLE
WRAN-708-release-properties-fix

### DIFF
--- a/ENCODE_release.py
+++ b/ENCODE_release.py
@@ -157,6 +157,9 @@ class Data_Release():
         self.searched = []
         self.connection = connection
         temp = encodedcc.get_ENCODE("/profiles/", self.connection)
+        # Fix for WRAN-708, new objects in profiles that don't have properties.
+        temp = {k: v for k, v in temp.items()
+                if not k.startswith('_') or v.get('properties') is not None}
 
         ignore = ["Lab", "Award", "Platform",
                   "Organism", "Reference", "AccessKey", "User", "AnalysisStep",


### PR DESCRIPTION
New _subtype object in /profiles/ causes ENCODE_release to fail. This ticket filters objects that start with underscore or have no properties field. 