### PR TITLE
WRAN-704-get-all-fields-fix-alt

### DIFF
--- a/encodedcc.py
+++ b/encodedcc.py
@@ -466,7 +466,8 @@ class GetFields():
         import csv
         from collections import deque
         self.setup()
-        self.header = ["accession"]
+        if not self.args.allfields:
+            self.header = ["accession"]
         for acc in self.accessions:
             acc = quote(acc)
             obj = get_ENCODE(acc, self.connection)


### PR DESCRIPTION
Fixes bug where header list is built up when --allfields flag is specified and then overwritten when normal flow continues, resulting in `dict contains fields not in fieldnames` error from csv.DictWriter.