### PR TITLE
Fix OpenUCSCGenomeBrowserCE11 and DownloadBEDFileFromModal.

### DIFF
--- a/qancode/defaults.py
+++ b/qancode/defaults.py
@@ -250,7 +250,7 @@ class ActionTuples:
              OpenUCSCGenomeBrowserDM6),
             ('/search/?type=Experiment&assembly=ce10&target.investigated_as=transcription+factor&replicates.library.biosample.life_stage=L4+larva',
              OpenUCSCGenomeBrowserCE10),
-            ('/search/?type=Experiment&assembly=ce11&target.investigated_as=recombinant+protein&replicates.library.biosample.life_stage=late+embryonic&replicates.library.biosample.life_stage=L4+larva',
+            ('/search/?type=Experiment&assembly=ce11&target.investigated_as=recombinant+protein&replicates.library.biosample.life_stage=early+embryonic&replicates.library.biosample.life_stage=L4+larva',
              OpenUCSCGenomeBrowserCE11),
             ('/search/?searchTerm=hippocampus&type=Experiment',
              OpenUCSCGenomeBrowserHG19)

--- a/qancode/pageobjects.py
+++ b/qancode/pageobjects.py
@@ -114,7 +114,7 @@ class InformationModal:
     """
     Page object model.
     """
-    download_icon_xpath = '/html/body/div[2]/div/div/div[1]/div/div/div[2]/div/dl/div[8]/dd/span/div/span/a/i'
+    download_icon_xpath = '//div[@class="modal-body"]//i[@class="icon icon-download"]'
 
 
 class NavBar:


### PR DESCRIPTION
* OpenUCSCGenomeBrowserCE11 for a set of experiments
Current search criteria hit >100 experiments which disable visualization

* DownloadBEDFileFromModal
XPath for download icon changed